### PR TITLE
Disable link preview in messages

### DIFF
--- a/doPost.gs
+++ b/doPost.gs
@@ -236,15 +236,16 @@ function makeLog(message, username) {
 
 function sendMessage(chatId, message) {
   var payload = {
-          'method': 'sendMessage',
-          'chat_id': String(chatId),
-          'text': message,
-          'parse_mode': 'HTML'
-        }     
-        var data = {
-          "method": "post",
-          "payload": payload
-        }
-        var API_TOKEN = 'YOUR_TOKEN'
-        UrlFetchApp.fetch('https://api.telegram.org/bot' + API_TOKEN + '/', data);
+    'method': 'sendMessage',
+    'chat_id': String(chatId),
+    'text': message,
+    'parse_mode': 'HTML',
+    'disable_web_page_preview': false
+  }     
+  var data = {
+    "method": "post",
+    "payload": payload
+  }
+  var API_TOKEN = 'YOUR_TOKEN'
+  UrlFetchApp.fetch('https://api.telegram.org/bot' + API_TOKEN + '/', data);
 }


### PR DESCRIPTION
Предлагаю офнуть превью ссылок в сообщениях, потому что все ссылки подписаны, а превью представляет из себя скрин таблицы, что не особо информативно.